### PR TITLE
Swift define variable convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ xcuserdata
 # Carthage/Checkouts
 
 Carthage/Build
+.DS_Store

--- a/LFSideViewController/LFSideViewController.swift
+++ b/LFSideViewController/LFSideViewController.swift
@@ -41,7 +41,7 @@ open class LFSideViewController: UIViewController {
     open var leftViewControllerVisible: Bool = false
     open var rightViewControllerVisible: Bool = false
     
-    open weak var leftViewController : UIViewController? {
+    open weak var leftViewController: UIViewController? {
         willSet {
             if let leftViewController = self.leftViewController {
                 leftViewController.removeFromParentViewController()
@@ -59,7 +59,7 @@ open class LFSideViewController: UIViewController {
         }
     }
     
-    open weak var rightViewController : UIViewController? {
+    open weak var rightViewController: UIViewController? {
         willSet {
             if let rightViewController = self.rightViewController {
                 rightViewController.removeFromParentViewController()
@@ -77,7 +77,7 @@ open class LFSideViewController: UIViewController {
         }
     }
     
-    open weak var contentViewController : UIViewController? {
+    open weak var contentViewController: UIViewController? {
         willSet {
             if let contentViewController = self.contentViewController {
                 contentViewController.removeFromParentViewController()
@@ -100,7 +100,7 @@ open class LFSideViewController: UIViewController {
         self.view.insertSubview(self.contentView!, at: 0)
     }
     
-    override open var shouldAutorotate : Bool {
+    override open var shouldAutorotate: Bool {
         if let topViewController = self.topViewController() {
             return topViewController.shouldAutorotate
         }
@@ -108,7 +108,7 @@ open class LFSideViewController: UIViewController {
         return super.shouldAutorotate
     }
     
-    override open var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if let topViewController = self.topViewController() {
             return topViewController.supportedInterfaceOrientations
         }


### PR DESCRIPTION
remove spacing between `var` name and `:`